### PR TITLE
Nachfrage

### DIFF
--- a/UserRoles_Guest.dita
+++ b/UserRoles_Guest.dita
@@ -8,7 +8,7 @@
     <p>If a guest is given no status (Reader/Updater), he or she will not be able to see the
       database objects in the corpus with a visibility status: Reader, Group, or Project. However
       the entire corpora with one of the statuses will still be displayed for her/him and the
-      database objects within it will be viewable.</p>
+      database objects within it will be viewable. ??Das verstehe ich nicht??</p>
     <p>Even if a guest has not been given such status for a particular corpus, they will still be
       able to view its content.</p>
     <p>A guest may view the lemma and the thesaurus views.


### PR DESCRIPTION
Der Zusammenhang zwischen Guest-Status und Visibility wird so
dargestellt, dass sie nicht mit meiner Nutzererfahrung übereinstimmt:
Wenn ein Objekt nicht public ist, kann ein Guest es nicht sehen!
Corpora, die nur Reader-Status haben, können von Guests nicht gesehen
werden!